### PR TITLE
Upgrade to Astro 6.3.3 + Cloudflare Workers with email, security, and analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # All in for Sport - Environment Variables
-# Copy this file to .env.local and fill in your values
+# Copy this file to .env and fill in your values
 
 # ===========================
 # Feature Flags
@@ -8,14 +8,6 @@
 # Enable/disable the blog/updates section on the homepage
 # Set to "true" to show featured updates, "false" to hide
 PUBLIC_FEATURE_BLOG=true
-
-# ===========================
-# Formspark Contact Form
-# ===========================
-
-# Your Formspark form ID for the contact form
-# Sign up at https://formspark.io to get a form ID
-PUBLIC_FORMSPARK_FORM_ID=your_formspark_form_id_here
 
 # ===========================
 # Alchemy API (Optional)

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ npm-debug.log*
 
 # cloudflare
 .wrangler
+
+# session artifacts
+.tmp/

--- a/README.md
+++ b/README.md
@@ -2,297 +2,185 @@
 
 > A Coordi-nation for grassroots sports projects
 
-All in for Sport is a network of projects supporting community-led initiatives that advance inclusion and empowerment through sport. This repository contains the official website built with Next.js, showcasing our mission, projects, and community updates.
+All in for Sport is a network of projects supporting community-led initiatives that advance inclusion and empowerment through sport. This repository contains the official website built with Astro, showcasing our mission, projects, and community updates.
 
-## 🌐 Live Site
+## Live Site
 
 Visit us at [allinforsport.org](https://allinforsport.org)
 
-## ✨ Features
+## Features
 
-- **📝 MDX-based Content Management** - Dynamic blog/updates system powered by Contentlayer
-- **👤 ENS Avatar Integration** - Automatic author avatar fetching from Ethereum Name Service
-- **🎨 Modern Design** - Responsive UI with Tailwind CSS and custom brand styling
-- **📧 Contact Forms** - Integrated contact system with Formspark
-- **🖼️ Optimized Images** - Advanced image optimization for fast static sites
-- **🚀 Static Site Generation** - Full SSG for optimal performance and hosting flexibility
-- **🎯 Feature Flags** - Toggle features via environment variables
-- **🌍 Social Integration** - Connected with Discord, Telegram, X, LinkedIn, and Web3 platforms
+- **MDX-based Content** — Blog/updates system powered by Astro Content Collections with Zod schemas
+- **ENS Avatar Integration** — Automatic author avatar fetching from Ethereum Name Service
+- **Modern Design** — Responsive UI with Tailwind CSS v4 and custom brand styling
+- **Contact Form** — Cloudflare Email Service integration via Worker API route
+- **OG Image Generation** — Build-time Open Graph images via satori + sharp
+- **Static Site Generation** — Full SSG for optimal performance
+- **View Transitions** — Smooth SPA-style page transitions with built-in prefetch
+- **Cloudflare Fonts** — Privacy-first font delivery served from own domain
+- **Security Headers** — CSP, HSTS, and permissive policy enforced at the edge
 
-## 🛠️ Technology Stack
+## Technology Stack
 
-- **Framework:** [Next.js 14](https://nextjs.org/) with App Router
-- **Language:** TypeScript
-- **Styling:** Tailwind CSS with custom theme
-- **Content:** Contentlayer for MDX processing
-- **Forms:** Formspark integration
-- **Blockchain:** viem for ENS resolution
-- **Fonts:** Red Hat Display (headers) & DM Sans (body)
-- **Image Optimization:** next-export-optimize-images
-- **Package Manager:** pnpm
+| Layer | Technology |
+|-------|-----------|
+| Framework | [Astro 6](https://astro.build/) (static output) |
+| Language | TypeScript (strict) |
+| Styling | [Tailwind CSS v4](https://tailwindcss.com/) with `@tailwindcss/vite` |
+| Content | MDX via `astro:content` with Zod validation |
+| Fonts | Red Hat Display & DM Sans (via Google Fonts, rewritten by Cloudflare Fonts) |
+| Deployment | [Cloudflare Workers](https://workers.cloudflare.com/) with Workers Assets |
+| Email | Cloudflare Email Service (`env.EMAIL.send()`) |
+| Analytics | [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/) (auto-injected) |
+| Runtime | Node 22 (build only — Workers serve static output) |
+| Package manager | npm |
+| Formatting | [Prettier](https://prettier.io/) with `prettier-plugin-astro` |
 
-## 📋 Prerequisites
+## Quick Start
 
-- Node.js 18+
-- pnpm (recommended) or npm
+### Prerequisites
 
-## 🚀 Quick Start
+- Node.js 22+
+- npm
+- Cloudflare account (for deployment)
 
 ### Installation
 
 ```bash
-# Clone the repository
 git clone https://github.com/All-In-For-Sport/aifs-site.git
 cd aifs-site
-
-# Install dependencies
-pnpm install
+npm install
 ```
 
 ### Environment Variables
 
-Create a `.env.local` file in the root directory:
+Copy `.env.example` to `.env` and fill in your values:
 
 ```env
 # Feature Flags
-NEXT_PUBLIC_FEATURE_BLOG=true
+PUBLIC_FEATURE_BLOG=true
 
-# Formspark Contact Form
-NEXT_PUBLIC_FORMSPARK_FORM_ID=your_formspark_form_id
-
-# Alchemy API for ENS Avatars (optional, for author avatars)
-NEXT_PUBLIC_ALCHEMY_API_KEY=your_alchemy_api_key
+# Alchemy API for ENS Avatars (optional)
+PUBLIC_ALCHEMY_API_KEY=your_alchemy_api_key
 ```
 
 ### Development
 
 ```bash
-# Start development server
-pnpm dev
-
-# Open http://localhost:3000 in your browser
+npm run dev          # Start dev server (http://localhost:4321)
+npm run build        # Production build to dist/
+npm run preview      # Preview with Wrangler
+npm run typecheck    # TypeScript type checking (astro check)
+npm run format       # Format with Prettier
 ```
 
-### Build
+### Deployment
 
 ```bash
-# Build for production
-pnpm build
-
-# Preview production build locally
-pnpm preview
+npm run deploy       # Build + deploy to Cloudflare Workers
 ```
 
-### Code Quality
-
-```bash
-# Run ESLint
-pnpm lint
-
-# Format code with Prettier
-pnpm format
-```
-
-## 📁 Project Structure
+## Project Structure
 
 ```
 aifs-site/
-├── app/                    # Next.js App Router
-│   ├── about/             # About page and components
-│   ├── features/          # Feature flag system
-│   ├── home/              # Homepage components
-│   ├── privacy/           # Privacy/Terms page
-│   ├── services/          # ENS and other services
-│   ├── shared/            # Shared components (Header, Footer, etc.)
-│   ├── updates/           # Blog/updates system
-│   ├── layout.tsx         # Root layout
-│   ├── page.tsx           # Homepage
-│   ├── siteMeta.ts        # Site links and metadata
-│   └── globals.css        # Global styles
-├── public/                # Static assets
-│   └── assets/            # Images and media
-├── updates/               # MDX content files
-├── contentlayer.config.ts # Contentlayer configuration
-├── next.config.js         # Next.js configuration
-├── tailwind.config.ts     # Tailwind CSS configuration
-└── types.ts               # TypeScript type definitions
+├── src/
+│   ├── components/          # UI components
+│   │   ├── about/           # About page sections
+│   │   ├── home/            # Homepage sections (Hero, Contact, Video, etc.)
+│   │   ├── shared/          # Shared components (Header, Footer, BaseHead)
+│   │   └── updates/         # Blog/updates components
+│   ├── content/             # MDX content files
+│   │   └── updates/         # Blog posts and events
+│   ├── content.config.ts    # Astro Content Collections schema
+│   ├── data/                # Static data (projects, site links)
+│   ├── index.ts             # Cloudflare Worker entrypoint
+│   ├── layouts/             # Page layouts (BaseLayout)
+│   ├── pages/               # Routes
+│   │   ├── about/           # /about
+│   │   ├── og/              # /og/[slug].png (build-time OG images)
+│   │   ├── privacy/         # /privacy
+│   │   ├── updates/         # /updates/[category]/[slug]
+│   │   └── index.astro      # /
+│   └── styles/              # Global CSS + Tailwind
+├── astro.config.ts          # Astro configuration
+├── wrangler.jsonc           # Cloudflare Workers configuration
+├── package.json             # Dependencies and scripts
+└── .env.example             # Environment variable template
 ```
 
-## 📝 Content Management
+## Content Management
 
 ### Creating Blog Posts/Updates
 
-1. Create an MDX file in the `/updates` directory
-2. Add required frontmatter:
+Create an MDX file in `src/content/updates/`:
 
 ```mdx
 ---
 title: Your Post Title
 author: Author Name
-authorEns: author.eth                    # Optional: ENS name
-authorEnsAvatar: true                    # Optional: Show ENS avatar
-category: event                          # event, article, etc.
-categoryPlural: events                   # Plural form for URLs
-group: Group Name                        # Optional: Project group
-featuredImage: image.webp                # Optional: Featured image
-featuredImageAltText: Image description  # Optional: Alt text
-date: 2024-01-01                        # Publication date
-isPublished: true                        # Visibility
-isFeatured: true                         # Show on homepage
-metaDescription: SEO description         # Optional: Custom meta
+authorEns: author.eth              # Optional: ENS name
+authorEnsAvatar: true              # Optional: Show ENS avatar
+category: event                    # event, article, etc.
+categoryPlural: events             # Plural form for URLs
+group: Group Name                  # Optional: Project group
+featuredImage: image.webp          # Optional: Featured image
+featuredImageAltText: Alt text     # Optional: Alt text
+date: 2024-01-01                   # Publication date
+isPublished: true                  # Visibility
+isFeatured: true                   # Show on homepage
+metaDescription: SEO description   # Optional: Custom meta
 ---
 
 Your content here...
 ```
 
-3. Place images in `/public/updates/`
-4. Posts are automatically generated at `/updates/{categoryPlural}/{filename}`
+Posts auto-generate at `/updates/{categoryPlural}/{filename}`.
 
 ### Content Categories
 
-Posts are organized by category:
-- **Events** - Upcoming and past events
-- **Articles** - Blog posts and news
+- **Events** — Upcoming and past events
+- **Articles** — Blog posts and news
 - Custom categories can be added as needed
 
 ### Featured Posts
 
-Set `isFeatured: true` to display posts on the homepage (when `NEXT_PUBLIC_FEATURE_BLOG=true`)
+Set `isFeatured: true` to display posts on the homepage (requires `PUBLIC_FEATURE_BLOG=true`).
 
-## 🎨 Customization
+## Architecture
 
-### Brand Colors
+### Worker Entrypoint (`src/index.ts`)
 
-Edit `tailwind.config.ts`:
+The Worker processes all requests before static assets:
 
-```ts
-colors: {
-  primary: "#2AA0F6",      // Primary blue
-  secondary: "#F301F8",    // Secondary magenta
-  background: "#111111",   // Dark background
-  darkText: "#242424",     // Dark text
-  bluegrey: "#1f2937",     // Blue-grey accent
-}
-```
+- **Security headers**: CSP, HSTS (`max-age=63072000; includeSubDomains; preload`), `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`
+- **Email API**: `POST /api/contact` → `env.EMAIL.send()` from `submissions@hosting.allinforsport.org` to `contact@allinforsport.org`
+- **CORS**: Restricted to `https://allinforsport.org`
+- **Static assets**: Proxied via `env.ASSETS.fetch()`
 
-### Fonts
+### Font Strategy
 
-Configured in `app/layout.tsx`:
-- **Headers:** Red Hat Display
-- **Body:** DM Sans
+Google Fonts `<link>` tags are rewritten at the edge by [Cloudflare Fonts](https://developers.cloudflare.com/speed/optimization/content/fonts/) to serve from `/cf-fonts/` on the same domain — no third-party font requests, compliant with `font-src 'self'` CSP.
 
-### Feature Flags
+### Analytics
 
-Control features via environment variables in `app/features/getFeatures.ts`:
+[Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/) auto-injects the RUM beacon for proxied traffic — no manual snippet needed. Data reports to `/cdn-cgi/rum` on the same domain, covered by `connect-src 'self'`.
 
-```ts
-export function getFeatures() {
-  const BLOG = process.env.NEXT_PUBLIC_FEATURE_BLOG === "true";
-  return { BLOG };
-}
-```
+### View Transitions
 
-## 🔗 Integrations & Links
+Astro's `<ClientRouter />` enables SPA-style page transitions with automatic link prefetching on hover. No full-page reloads between routes.
 
-The site integrates with multiple platforms (configured in `app/siteMeta.ts`):
+## Integrations & Links
 
-- **Community:**
-  - Discord: Community discussions
-  - Telegram: Updates and announcements
-  - X (Twitter): Social media
-  - LinkedIn: Professional network
+Configured in `src/data/site-meta.ts`:
 
-- **Web3:**
-  - Hats Protocol: Role management
-  - OpenSea: NFT collection
-  - Snapshot: Governance voting
-  - ENS: Ethereum Name Service for author profiles
+- **Community**: Discord, Telegram, X (Twitter), LinkedIn
+- **Web3**: Hats Protocol, OpenSea, Snapshot, ENS
+- **Other**: Discussion Forum, Luma Events, Bonfire Streams
 
-- **Other:**
-  - Discussion Forum: discuss.allinforsport.org
-  - Events: Luma calendar integration
-  - Stream Archive: Bonfire recordings
+## License
 
-## 🚢 Deployment
-
-This site is configured for static export:
-
-```bash
-# Build static site
-pnpm build
-
-# Output directory
-out/
-```
-
-The `out/` directory contains the complete static site ready for deployment to:
-- Vercel
-- Netlify
-- GitHub Pages
-- Any static hosting service
-- IPFS/Fleek for decentralized hosting
-
-### Build Process
-
-1. Next.js builds pages
-2. Contentlayer processes MDX files
-3. next-export-optimize-images optimizes images
-4. Static HTML/CSS/JS exported to `/out`
-
-## 🎯 Key Technical Decisions
-
-### Why Static Export?
-- **Performance:** Pre-rendered pages load instantly
-- **Hosting Flexibility:** Deploy anywhere
-- **Cost Effective:** No server required
-- **Web3 Ready:** Easy IPFS deployment
-
-### Why Contentlayer?
-- **Type Safety:** Auto-generated TypeScript types
-- **Developer Experience:** MDX with React components
-- **Build Time Processing:** Fast runtime performance
-- **Flexible Schema:** Easy content modeling
-
-### Why ENS Integration?
-- **Web3 Native:** Align with decentralized community
-- **Author Attribution:** Verifiable identities
-- **Avatar System:** Automatic profile images
-
-## 🤝 Contributing
-
-We welcome contributions! Here's how you can help:
-
-1. **Content Contributions:** Add blog posts via MDX files
-2. **Bug Reports:** Open issues for bugs
-3. **Feature Requests:** Suggest improvements
-4. **Code Contributions:** Submit pull requests
-
-### Development Workflow
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run `pnpm format` and `pnpm lint`
-5. Submit a pull request
-
-## 📄 License
-
-This project is open source. Please check with the All in for Sport team for specific licensing terms.
-
-## 🆘 Support
-
-- **Website:** [allinforsport.org](https://allinforsport.org)
-- **Discord:** [Join our community](https://discord.com/invite/HyeK5hf4vR)
-- **Telegram:** [Get updates](https://t.me/+CW0_qRG6S5g1MmJh)
-- **X:** [@allinforsport](https://x.com/allinforsport)
-
-## 🙏 Acknowledgments
-
-Built with support from:
-- Krause House
-- Project Backboard
-- Word 2 The Wise Festival
-- The broader Web3 and grassroots sports communities
+This project is open source. Check with the All in for Sport team for specific licensing terms.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.0",
+        "@cloudflare/workers-types": "^4.20260517.1",
         "prettier": "^3.8.3",
         "prettier-plugin-astro": "^0.14.1",
         "satori": "^0.26.0",
@@ -406,6 +407,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260517.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260517.1.tgz",
+      "integrity": "sha512-OjavgX6VpYoWlKg2xPgLKIhBeiJvNdwFVK8E1P6hF02wh1oEt1sZpTzbp9kdohprqjXo6UVqs7/AuIH0wxIcbw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "astro build",
     "preview": "wrangler dev",
     "deploy": "astro build && wrangler deploy",
+    "typecheck": "astro check",
     "format": "prettier --write . --plugin prettier-plugin-astro",
     "astro": "astro"
   },
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",
+    "@cloudflare/workers-types": "^4.20260517.1",
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1",
     "satori": "^0.26.0",

--- a/src/components/home/Contact.astro
+++ b/src/components/home/Contact.astro
@@ -97,20 +97,21 @@
 <script>
   const form = document.getElementById('contact-form') as HTMLFormElement;
   const status = document.getElementById('form-status');
-  const FORM_ID = import.meta.env.PUBLIC_FORMSPARK_FORM_ID;
+  const submitBtn = form?.querySelector('button[type="submit"]') as HTMLButtonElement;
 
   form?.addEventListener('submit', async (e) => {
     e.preventDefault();
+    if (!form || !status) return;
+
     const formData = new FormData(form);
-    const submitBtn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
 
     try {
       submitBtn.disabled = true;
       submitBtn.textContent = 'Sending...';
 
-      await fetch(`https://submit-form.com/${FORM_ID}`, {
+      const res = await fetch('/api/contact', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: formData.get('name'),
           email: formData.get('email'),
@@ -118,16 +119,19 @@
         }),
       });
 
-      if (status) {
-        status.textContent = 'Message sent! Our team will be in touch shortly.';
-        status.className = 'text-sm text-green-400';
+      const data = (await res.json()) as { message?: string; error?: string };
+
+      if (res.ok) {
+        status.textContent = data.message ?? null;
+        status.className = 'text-sm font-medium text-green-400';
+        form.reset();
+      } else {
+        status.textContent = data.error ?? null;
+        status.className = 'text-sm font-medium text-red-400';
       }
-      form.reset();
     } catch {
-      if (status) {
-        status.textContent = 'Something went wrong. Please try again.';
-        status.className = 'text-sm text-red-400';
-      }
+      status.textContent = 'Something went wrong. Please try again.';
+      status.className = 'text-sm font-medium text-red-400';
     } finally {
       submitBtn.disabled = false;
       submitBtn.textContent = 'Submit';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,124 @@
+/// <reference types="@cloudflare/workers-types" />
+
+interface Env {
+  ASSETS: Fetcher;
+  EMAIL: SendEmail;
+}
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': 'https://allinforsport.org',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+const SECURITY_HEADERS: Record<string, string> = {
+  'X-Frame-Options': 'DENY',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+};
+
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https:",
+  "font-src 'self'",
+  "connect-src 'self' https://cloudflareinsights.com",
+  "frame-src 'none'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join('; ');
+
+function applyHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  for (const [k, v] of Object.entries(SECURITY_HEADERS)) {
+    headers.set(k, v);
+  }
+  headers.set('Content-Security-Policy', CSP);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+async function handleContact(request: Request, env: Env): Promise<Response> {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  if (request.method !== 'POST') {
+    return Response.json(
+      { error: 'Method not allowed' },
+      { status: 405, headers: CORS_HEADERS }
+    );
+  }
+
+  try {
+    const body = (await request.json()) as {
+      name?: string;
+      email?: string;
+      message?: string;
+    };
+    const { name, email, message } = body;
+
+    if (!name || !email || !message) {
+      return Response.json(
+        { error: 'Name, email, and message are required' },
+        { status: 400, headers: CORS_HEADERS }
+      );
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return Response.json(
+        { error: 'Invalid email address' },
+        { status: 400, headers: CORS_HEADERS }
+      );
+    }
+
+    const sanitize = (s: string) => s.replace(/<[^>]*>/g, '').trim();
+    const safeName = sanitize(name).slice(0, 200);
+    const safeEmail = sanitize(email).slice(0, 254);
+    const safeMessage = sanitize(message).slice(0, 5000);
+
+    await env.EMAIL.send({
+      from: 'submissions@hosting.allinforsport.org',
+      to: 'contact@allinforsport.org',
+      replyTo: safeEmail,
+      subject: `Contact form: ${safeName}`,
+      html: `<h2>New contact form submission</h2>
+<p><strong>Name:</strong> ${safeName}</p>
+<p><strong>Email:</strong> ${safeEmail}</p>
+<p><strong>Message:</strong></p>
+<p>${safeMessage.replace(/\n/g, '<br>')}</p>`,
+      text: `New contact form submission\n\nName: ${safeName}\nEmail: ${safeEmail}\n\nMessage:\n${safeMessage}`,
+    });
+
+    return Response.json(
+      { success: true, message: 'Message sent! Our team will be in touch shortly.' },
+      { headers: CORS_HEADERS }
+    );
+  } catch (e) {
+    console.error('Contact form error:', e);
+    return Response.json(
+      { error: 'Failed to send message. Please try again.' },
+      { status: 500, headers: CORS_HEADERS }
+    );
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/api/contact') {
+      return handleContact(request, env);
+    }
+
+    const response = await env.ASSETS.fetch(request);
+    return applyHeaders(response);
+  },
+} satisfies ExportedHandler<Env>;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from 'astro:transitions';
 import BaseHead from '@components/shared/BaseHead.astro';
 import Header from '@components/shared/Header.astro';
 import Footer from '@components/shared/Footer.astro';
@@ -17,12 +18,11 @@ const { title, description, image } = Astro.props;
 <html lang="en">
   <head>
     <BaseHead title={title} description={description ?? ''} image={image} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Red+Hat+Display:wght@300;400;500;600;700;800;900&display=swap"
       rel="stylesheet"
     />
+    <ClientRouter />
   </head>
   <body class="bg-background font-body text-white">
     <div class="background-image"></div>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,14 +1,29 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "aifs-site",
+  "main": "src/index.ts",
   "account_id": "c36c9a59f6251430c514f4fff55c3f4a",
-  "compatibility_date": "2025-12-01",
+  "compatibility_date": "2026-05-17",
+  "compatibility_flags": ["nodejs_compat"],
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
   },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  },
+  "send_email": [
+    {
+      "name": "EMAIL",
+      "allowed_sender_addresses": ["submissions@hosting.allinforsport.org"]
+    }
+  ],
   "routes": [
     {
-      "pattern": "allinforsport.superbenefit.dev",
+      "pattern": "allinforsport.org",
       "custom_domain": true
     }
   ]


### PR DESCRIPTION
## Summary

Upgrades the AIFS site from Astro 5.17.2 to Astro 6.3.3 with a Cloudflare Workers entrypoint for security headers, email contact form, and static asset serving.

## Changes

### Phase 1 — Astro 6 Upgrade
- Bump Astro 5.17.2 → 6.3.3, `@astrojs/mdx` → 5.0.6, Tailwind v4 + `@tailwindcss/vite`
- Pin `@tailwindcss/vite` to 4.1.18 (v4.2+ bundles Vite 8, conflicts with Astro 6's Vite 7)
- Add `overrides: { vite: 7.3.3 }` to `package.json` for single Vite version
- Move satori, satori-html, sharp from `dependencies` → `devDependencies` (build-time only)
- Switch site URL to `https://allinforsport.org`
- Add `@astrojs/check` for type checking, `@cloudflare/workers-types` for Worker types

### Phase 2 — Worker Entrypoint + Email Service
- **New**: `src/index.ts` — Worker entrypoint with security headers (CSP, HSTS, X-Frame-Options, etc.), `POST /api/contact` → `env.EMAIL.send()`, CORS, input sanitization
- **Rewrite**: `wrangler.jsonc` — Workers Assets config, `run_worker_first: true`, `send_email` binding, observability, prod routes
- **Update**: `Contact.astro` — replace Formspark with `POST /api/contact` + type-safe states
- Email flow: `submissions@hosting.allinforsport.org` → `contact@allinforsport.org`

### Phase 3 — Analytics + Cleanup
- Cloudflare Web Analytics (auto-injected for proxied traffic, no manual snippet)
- Remove `PUBLIC_FORMSPARK_FORM_ID` from `.env.example`

### Phase 4 — Fonts + Transitions
- **Cloudflare Fonts** — dashboard toggle, edge rewrite Google Fonts → `/cf-fonts/` (own domain)
- Remove Google Fonts preconnect `<link>` tags (dead code after CF Fonts)
- Add `<ClientRouter />` from `astro:transitions` — SPA View Transitions + prefetch
- Add `typecheck` script (`astro check`)

### Phase 5 — Documentation + Cleanup
- Rewrite `README.md` (was Next.js 14 + Contentlayer + pnpm — now Astro 6 + Workers + npm)
- Update `technical-domain.md` context file
- Update `.gitignore` — add `.tmp/`

## Build Status

| Check | Status |
|-------|--------|
| `npm run build` | ✓ 6 pages, ~4.5s |
| `npm run typecheck` | ✓ (2 preexisting errors only — camelCase attr + Buffer type) |
| `wrangler deploy --dry-run` | ✓ bindings confirmed |

## Pre-existing Issues (not caused by this PR)
- `Video.astro:14` — `disableremoteplayback` should be `disableRemotePlayback` (camelCase attrs)
- `og/[...slug].png.ts:96` — `Buffer` type incompatible with `Response` body
- `package-lock.json` — will be regenerated on first `npm install`